### PR TITLE
Fix issues with statistics box

### DIFF
--- a/public/res/scripts/bibordle.js
+++ b/public/res/scripts/bibordle.js
@@ -127,7 +127,7 @@ class Game {
         state.lineId++;
         state.letterId = 0;
         state.currentGuess = "";
-        this.getCurrentLine().classList.remove("dimmed");
+        this.getCurrentLine()?.classList.remove("dimmed");
     }
 }
 
@@ -307,7 +307,7 @@ function restoreLastGame() {
         }
     });
 
-    if (state.guessedWords.length === 5 || state.guessedWords.includes(state.solution)) {
+    if (state.guessedWords.length === 6 || state.guessedWords.includes(state.solution)) {
         state.lineId--;
         state.gameEnabled = false;
         showStats();


### PR DESCRIPTION
There was an issue in which the game stats did not pop up after refreshing the page.

This pull request fixes a bug in which the game would become unplayable and the stats page would pop up saying you lost if there had been five guesses and then a refresh.

It also fixes a bug in which the stats page does not pop up if there has been six guesses or the user won on the sixth guess.

## Changes

 - Added optional chaining operator when the `dimmed` class is removed from lines to prevent errors when line number is 6 (Line 130, bibordle.js)
 - Modified show stats check to check if `state.guessedWords.length` is 6, rather than 5, as `length` is not zero-based (Line 310, bibordle.js)
